### PR TITLE
Consider: detect expandtab

### DIFF
--- a/ftplugin/matlab_fold.vim
+++ b/ftplugin/matlab_fold.vim
@@ -75,24 +75,24 @@ function! GetLineIndent(lnum, ...)
         if directionForward == 0
             " For blank lines, return the indent of the most indented surrounding line
             " Use the second argument to force the recursion to proceed in a
-            " specific direction outward from this line 
-            return max([GetLineIndent(nextnonblank(a:lnum+1),1), GetLineIndent(prevnonblank(a:lnum-1),-1)]) 
+            " specific direction outward from this line
+            return max([GetLineIndent(nextnonblank(a:lnum+1),1), GetLineIndent(prevnonblank(a:lnum-1),-1)])
 
         elseif directionForward == 1
             " Just check the subsequent line
             return GetLineIndent(nextnonblank(a:lnum+1), 1)
-        else " directionForward == -1 
+        else " directionForward == -1
             " Just check the previous line
             return GetLineIndent(prevnonblank(a:lnum-1), -1)
         end
 
     else
-        " Nothing special, just return the actual indent + 1, which allows for 
+        " Nothing special, just return the actual indent + 1, which allows for
         " cell-mode folding of unindented lines
-        return indent(a:lnum) + 1 
+        " return indent(a:lnum) + 1
 
         " if you're trying to debug, i'd recommend changing the above to:
-        " return indent(a:lnum) / &ts + 1
+        return indent(a:lnum) / &ts + 1
         " to make the indent levels equal to the number of tabs rather than
         " spaces, and then use set foldcolumn=10 to see the folds visually
     endif


### PR DESCRIPTION
I don't understand the reason for the default behavior on line 92; when I edit MATLAB code I'm forced to use four spaces for indentation, and swapping in line 95 works well for me (which divides indent(...) by ts).

Is the default intended for people who can use tabs?  If so, this could be improved by considering `et` vs. `noet` for users of spaces.
